### PR TITLE
Update script.js

### DIFF
--- a/public/script.js
+++ b/public/script.js
@@ -647,9 +647,9 @@ $(document).ready(function(){
                     $("#main_api").val("kobold");
                     $("#main_api").change();
                     if(String(getData.colaburl).indexOf('cloudflare')){
-                        url = String(getData.colaburl).split("flare.com")[0] + "flare.com";
+                        url = String(getData.colaburl).split("flare.com")[0] + "";
                     }else{
-                        url = String(getData.colaburl).split("loca.lt")[0] + "loca.lt";
+                        url = String(getData.colaburl).split("loca.lt")[0] + "";
                     }
                     $('#api_url_text').val(url);
                     setTimeout(function () {


### PR DESCRIPTION
"Quit adding 'flare.com' or 'loca.lt' to the end of http://127.0.0.1:5000/api... Please."
![image](https://github.com/TavernAI/TavernAIColab/assets/123712145/40a7f1da-0cdc-4dc0-a79f-ba0852fbfe76)


(This is the COLAB BRANCH. The API URL is _ALWAYS_ going to be http://127.0.0.1:5000/api  This *really* confuses people on the main branch too when their connection drops and they hit the connect button again and it refuses to connect...  Few (but me!) notice the damnable _extra_ loca.lt and flare.com appended to the end of their previously valid pasted url...



Please and Thank You.
--FunkEngine